### PR TITLE
Change nbplatform.active to default

### DIFF
--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -4,4 +4,4 @@ cluster.path=\
     ${nbplatform.active.dir}/php:\
     ${nbplatform.active.dir}/platform:\
     ${nbplatform.active.dir}/websvccommon
-nbplatform.active=nb721
+nbplatform.active=default


### PR DESCRIPTION
I think that nbplatform.active should be default since other people have to change it for build.

Thanks!
