### PR TITLE
Add actions to editor context menu and editor toolbar

### DIFF
--- a/src/flow/netbeans/markdown/MarkdownGenerateHtmlAction.java
+++ b/src/flow/netbeans/markdown/MarkdownGenerateHtmlAction.java
@@ -26,7 +26,9 @@ import org.pegdown.PegDownProcessor;
 id = "flow.netbeans.markdown.GenerateHtmlAction")
 @ActionRegistration(displayName = "#CTL_GenerateHtmlAction")
 @ActionReferences({
-   @ActionReference(path = "Loaders/text/x-markdown/Actions", position = 250)
+    @ActionReference(path = "Editors/text/x-markdown/Toolbars/Default", position = 270000),
+    @ActionReference(path = "Editors/text/x-markdown/Popup", position = 0),
+    @ActionReference(path = "Loaders/text/x-markdown/Actions", position = 250)
 })
 @Messages("CTL_GenerateHtmlAction=Generate HTML")
 public final class MarkdownGenerateHtmlAction implements ActionListener {

--- a/src/flow/netbeans/markdown/MarkdownViewHtmlAction.java
+++ b/src/flow/netbeans/markdown/MarkdownViewHtmlAction.java
@@ -25,6 +25,8 @@ import org.pegdown.PegDownProcessor;
 id = "flow.netbeans.markdown.MarkdownViewHtmlAction")
 @ActionRegistration(displayName = "#CTL_MarkdownViewHtmlAction")
 @ActionReferences({
+    @ActionReference(path = "Editors/text/x-markdown/Toolbars/Default", position = 270100),
+    @ActionReference(path = "Editors/text/x-markdown/Popup", position = 0),
     @ActionReference(path = "Loaders/text/x-markdown/Actions", position = 251)
 })
 @Messages("CTL_MarkdownViewHtmlAction=View HTML")


### PR DESCRIPTION
![nb-markdown-plugin-editor-toobar](https://f.cloud.github.com/assets/738383/263334/011ce69a-8d68-11e2-9537-83715a2c9495.png)
I have added two actions(generate and view) to editor context menu and editor toolbar.
We can run these actions on editor soon.

Thanks.
