### PR TITLE
Add code templates

### DIFF
--- a/src/flow/netbeans/markdown/resources/code-templates.xml
+++ b/src/flow/netbeans/markdown/resources/code-templates.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<!DOCTYPE codetemplates PUBLIC "-//NetBeans//DTD Editor Code Templates settings 1.0//EN" "http://www.netbeans.org/dtds/EditorCodeTemplates-1_0.dtd">
+<codetemplates>
+    <codetemplate contexts="md-code" abbreviation="1">
+        <code><![CDATA[# ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="2">
+        <code><![CDATA[## ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="3">
+        <code><![CDATA[### ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="4">
+        <code><![CDATA[#### ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="5">
+        <code><![CDATA[##### ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="6">
+        <code><![CDATA[###### ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="s">
+        <code><![CDATA[**${text}** ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="sselection">
+        <code><![CDATA[**${selection}**${cursor}]]></code>
+        <description>Markdown **|**</description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="i">
+        <code><![CDATA[*${text}* ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="iselection">
+        <code><![CDATA[*${selection}*${cursor}]]></code>
+        <description>Markdown *|*</description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="hr">
+        <code><![CDATA[---]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="link">
+        <code><![CDATA[[${name}](${http://}) ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="linkt">
+        <code><![CDATA[[${name}](${http://} "${title}" ${cursor})]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="linkid">
+        <code><![CDATA[[${id}]: ${http://} ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="linkidt">
+        <code><![CDATA[[${id}]: ${http://} "${title}" ${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="img">
+        <code><![CDATA[![${alt}](${path})]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="imgt">
+        <code><![CDATA[![${alt}](${path} "${title}")]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="c">
+        <code><![CDATA[`${code}`${cursor}]]></code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="cselection">
+        <code><![CDATA[`${selection}`${cursor}]]></code>
+        <description>Markdown `|`</description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="tbl">
+        <code><![CDATA[
+|${name1}|${name2}|${name3}|
+|-----|-----|-----|
+|${valu1}|${valu2}|${valu3}|]]>
+        </code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="tbll">
+        <code><![CDATA[
+|${name1}|${name2}|${name3}|
+|:----|:----|:----|
+|${valu1}|${valu2}|${valu3}|]]>
+        </code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="tblc">
+        <code><![CDATA[
+|${name1}|${name2}|${name3}|
+|:---:|:---:|:---:|
+|${valu1}|${valu2}|${valu3}|]]>
+        </code>
+        <description></description>
+    </codetemplate>
+    <codetemplate contexts="md-code" abbreviation="tblr">
+        <code><![CDATA[
+|${name1}|${name2}|${name3}|
+|----:|----:|----:|
+|${valu1}|${valu2}|${valu3}|]]>
+        </code>
+        <description></description>
+    </codetemplate>
+</codetemplates>

--- a/src/flow/netbeans/markdown/resources/layer.xml
+++ b/src/flow/netbeans/markdown/resources/layer.xml
@@ -76,6 +76,9 @@
     <folder name="Editors">
         <folder name="text">
             <folder name="x-markdown">
+                <folder name="CodeTemplates">
+                    <file name="code-templates.xml" url="code-templates.xml"/>
+                </folder>
                 <attr name="SystemFileSystem.localizingBundle" stringvalue="flow.netbeans.markdown.resources.Bundle"/>
                 <attr name="displayName" bundlevalue="flow.netbeans.markdown.resources.Bundle#Editors/text/x-markdown"/>
                 <file name="language.instance">


### PR DESCRIPTION
I added some code template.
### How to use
1. expand with `Tab` key  
   e.g. type `link` then `Tab` -> `[name](http://)` : first, stop at `name`, if we type something and press enter key, target text is moved `http://`.
2. code completion : i.e. `Ctrl` + `Space` (perhaps, NB74)  
   e.g. type `l` then `Ctrl` + `Space` : we can see some candidate items on code completion list. (link, linkt, ....)
3. surround text : `Alt` + `Enter`  
   select text then `Alt` + `Enter` : we can surround text with `*`, `**` and `

Thanks.
