### PR TITLE
Encapsulated HTML rendering of Markdown source in an API

### DIFF
--- a/src/flow/netbeans/markdown/MarkdownDataObject.java
+++ b/src/flow/netbeans/markdown/MarkdownDataObject.java
@@ -13,14 +13,26 @@ import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.util.lookup.AbstractLookup;
+import org.openide.util.lookup.InstanceContent;
+import org.openide.util.lookup.ProxyLookup;
 import org.openide.windows.TopComponent;
 
 public class MarkdownDataObject extends MultiDataObject {
     private static final long serialVersionUID = 1L;
 
+    private final Lookup lookup;
+
+    private final InstanceContent lookupContent;
+
     public MarkdownDataObject(FileObject pf, MultiFileLoader loader) throws DataObjectExistsException, IOException {
         super(pf, loader);
         registerEditor(MarkdownLanguageConfig.MIME_TYPE, true);
+
+        lookupContent = new InstanceContent();
+        lookupContent.add(new RenderableImpl(this));
+        
+        lookup = new ProxyLookup(getCookieSet().getLookup(), new AbstractLookup(lookupContent));
     }
 
     @Override
@@ -30,7 +42,7 @@ public class MarkdownDataObject extends MultiDataObject {
 
     @Override
     public Lookup getLookup() {
-        return getCookieSet().getLookup();
+        return lookup;
     }
 
     @Override

--- a/src/flow/netbeans/markdown/MarkdownOnSaveTask.java
+++ b/src/flow/netbeans/markdown/MarkdownOnSaveTask.java
@@ -2,12 +2,10 @@ package flow.netbeans.markdown;
 
 import flow.netbeans.markdown.csl.MarkdownLanguageConfig;
 import flow.netbeans.markdown.options.MarkdownGlobalOptions;
-import java.io.IOException;
 import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.modules.editor.NbEditorUtilities;
 import org.netbeans.spi.editor.document.OnSaveTask;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -32,12 +30,8 @@ public final class MarkdownOnSaveTask implements OnSaveTask{
 
         // view html
         if (MarkdownGlobalOptions.getInstance().isViewHtmlOnSave()) {
-            try {
-                MarkdownViewHtmlAction viewAction = new MarkdownViewHtmlAction(dataObject);
-                viewAction.actionPerformed(null);
-            } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
-            }
+            MarkdownViewHtmlAction viewAction = new MarkdownViewHtmlAction(dataObject);
+            viewAction.actionPerformed(null);
         }
     }
 

--- a/src/flow/netbeans/markdown/PreviewLinkRenderer.java
+++ b/src/flow/netbeans/markdown/PreviewLinkRenderer.java
@@ -1,0 +1,72 @@
+
+package flow.netbeans.markdown;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.pegdown.LinkRenderer;
+import org.pegdown.ast.AutoLinkNode;
+import org.pegdown.ast.ExpLinkNode;
+import org.pegdown.ast.MailLinkNode;
+import org.pegdown.ast.RefLinkNode;
+import org.pegdown.ast.WikiLinkNode;
+
+/**
+ *
+ * @author Holger Stenger
+ */
+public class PreviewLinkRenderer extends LinkRenderer {
+    private final URL baseUrl;
+
+    private final boolean resolveLinkUrls;
+
+    public PreviewLinkRenderer(URL baseUrl, boolean resolveLinkUrls) {
+        super();
+        this.baseUrl = baseUrl;
+        this.resolveLinkUrls = resolveLinkUrls;
+    }
+
+    @Override
+    public LinkRenderer.Rendering render(AutoLinkNode node) {
+        return transform(super.render(node));
+    }
+
+    @Override
+    public LinkRenderer.Rendering render(MailLinkNode node) {
+        return transform(super.render(node));
+    }
+
+    @Override
+    public LinkRenderer.Rendering render(WikiLinkNode node) {
+        return transform(super.render(node));
+    }
+
+    @Override
+    public LinkRenderer.Rendering render(ExpLinkNode node, String text) {
+        return transform(super.render(node, text));
+    }
+
+    @Override
+    public LinkRenderer.Rendering render(RefLinkNode node, String url, String title, String text) {
+        return transform(super.render(node, url, title, text));
+    }
+
+    private String resolveUrl(final String uriText) {
+        try {
+            return baseUrl.toURI().resolve(uriText).toURL().toExternalForm();
+        }
+        catch (URISyntaxException ex) {
+        }
+        catch (MalformedURLException ex) {
+        }
+        return uriText;
+    }
+
+    private LinkRenderer.Rendering transform(LinkRenderer.Rendering rendering) {
+        if (resolveLinkUrls && (rendering.href != null)) {
+            rendering.href = resolveUrl(rendering.href);
+        }
+        return rendering;
+    }
+
+}

--- a/src/flow/netbeans/markdown/PreviewSerializer.java
+++ b/src/flow/netbeans/markdown/PreviewSerializer.java
@@ -1,0 +1,59 @@
+package flow.netbeans.markdown;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.pegdown.LinkRenderer;
+import org.pegdown.ToHtmlSerializer;
+import org.pegdown.ast.AutoLinkNode;
+import org.pegdown.ast.ExpLinkNode;
+import org.pegdown.ast.MailLinkNode;
+import org.pegdown.ast.RefLinkNode;
+import org.pegdown.ast.SuperNode;
+import org.pegdown.ast.WikiLinkNode;
+
+/**
+ *
+ * @author Holger Stenger
+ */
+public class PreviewSerializer extends ToHtmlSerializer {
+    private final URL baseUrl;
+
+    private final boolean resolveImageUrls;
+
+    public PreviewSerializer(final URL baseUrl) {
+        this(baseUrl, true, false);
+    }
+
+    public PreviewSerializer(URL baseUrl, boolean resolveImageUrls, boolean resolveLinkUrls) {
+        super(new PreviewLinkRenderer(baseUrl, resolveLinkUrls));
+        this.baseUrl = baseUrl;
+        this.resolveImageUrls = resolveImageUrls;
+    }
+
+    private String resolveUrl(final String url) {
+        try {
+            return baseUrl.toURI().resolve(url).toURL().toExternalForm();
+        }
+        catch (URISyntaxException ex) {
+        }
+        catch (MalformedURLException ex) {
+        }
+        return url;
+    }
+
+    private String resolveImageUrl(final String url) {
+        if (resolveImageUrls) {
+            return resolveUrl(url);
+        }
+        else {
+            return url;
+        }
+    }
+
+    @Override
+    protected void printImageTag(SuperNode imageNode, String url) {
+        printer.print("<img src=\"").print(resolveImageUrl(url)).print("\"  alt=\"")
+                .printEncoded(printChildrenToString(imageNode)).print("\"/>");
+    }
+}

--- a/src/flow/netbeans/markdown/RenderableImpl.java
+++ b/src/flow/netbeans/markdown/RenderableImpl.java
@@ -1,0 +1,103 @@
+package flow.netbeans.markdown;
+
+import flow.netbeans.markdown.api.RenderOption;
+import flow.netbeans.markdown.api.Renderable;
+import flow.netbeans.markdown.options.MarkdownGlobalOptions;
+import java.io.IOException;
+import java.util.Set;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.StyledDocument;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.loaders.DataObject;
+import org.pegdown.ParsingTimeoutException;
+import org.pegdown.PegDownProcessor;
+import org.pegdown.ast.RootNode;
+
+public class RenderableImpl implements Renderable {
+    private static final String TITLE = "{%TITLE%}";
+
+    private static final String CONTENT = "{%CONTENT%}";
+
+    private static final String SWING_TEMPLATE = "<html><body>" + CONTENT;
+
+    private final DataObject context;
+
+    public RenderableImpl(DataObject context) {
+        this.context = context;
+    }
+
+    @Override
+    public String renderAsHtml(Set<RenderOption> renderOptions) throws IOException {
+        MarkdownGlobalOptions markdownOptions = MarkdownGlobalOptions.getInstance();
+        String sourceText = getSourceText(renderOptions);
+        String bodyText = renderBodyText(renderOptions, markdownOptions, sourceText);
+        return renderHtmlText(renderOptions, markdownOptions, bodyText);
+    }
+
+    private String renderBodyText(Set<RenderOption> renderOptions, MarkdownGlobalOptions markdownOptions,
+            String sourceText) throws IOException {
+        String bodyText;
+        try {
+            PegDownProcessor markdownProcessor = new PegDownProcessor(markdownOptions.getExtensionsValue());
+            final boolean resolveImageUrls = renderOptions.contains(RenderOption.RESOLVE_IMAGE_URLS);
+            final boolean resolveLinkUrls = renderOptions.contains(RenderOption.RESOLVE_LINK_URLS);
+            if (resolveImageUrls || resolveLinkUrls) {
+                RootNode rootNode = markdownProcessor.parseMarkdown(sourceText.toCharArray());
+                FileObject sourceFile = context.getPrimaryFile();
+                final PreviewSerializer htmlSerializer
+                        = new PreviewSerializer(sourceFile.toURL(), resolveImageUrls, resolveLinkUrls);
+                bodyText = htmlSerializer.toHtml(rootNode);
+            } else {
+                bodyText = markdownProcessor.markdownToHtml(sourceText);
+            }
+        }
+        catch (ParsingTimeoutException ex) {
+            throw new IOException(ex);
+        }
+        return bodyText;
+    }
+
+    private String getSourceText(Set<RenderOption> renderOptions) throws IOException {
+        String sourceText = null;
+        if (renderOptions.contains(RenderOption.PREFER_EDITOR)) {
+            EditorCookie ec = context.getLookup().lookup(EditorCookie.class);
+            StyledDocument sourceDoc = ec.getDocument();
+            if (sourceDoc != null) {
+                synchronized (sourceDoc) {
+                    try {
+                        sourceText = sourceDoc.getText(0, sourceDoc.getLength());
+                    }
+                    catch (BadLocationException ex) {
+                        throw new IOException(ex);
+                    }
+                }
+            }
+        }
+        if (sourceText == null) {
+            FileObject sourceFile = context.getPrimaryFile();
+            sourceText = sourceFile.asText();
+        }
+        return sourceText;
+    }
+
+    private String getHtmlTemplate(Set<RenderOption> renderOptions, MarkdownGlobalOptions markdownOptions) {
+        String htmlTemplate;
+        if (renderOptions.contains(RenderOption.SWING_COMPATIBLE)) {
+            htmlTemplate = SWING_TEMPLATE;
+        } else {
+            htmlTemplate = markdownOptions.getHtmlTemplate();
+        }
+        return htmlTemplate;
+    }
+
+    private String renderHtmlText(Set<RenderOption> renderOptions, MarkdownGlobalOptions markdownOptions,
+            String bodyText) {
+        String htmlTemplate = getHtmlTemplate(renderOptions, markdownOptions);
+        FileObject sourceFile = context.getPrimaryFile();
+        String htmlText = htmlTemplate
+                .replace(TITLE, sourceFile.getName())
+                .replace(CONTENT, bodyText);
+        return htmlText;
+    }
+}

--- a/src/flow/netbeans/markdown/api/RenderOption.java
+++ b/src/flow/netbeans/markdown/api/RenderOption.java
@@ -1,0 +1,17 @@
+
+package flow.netbeans.markdown.api;
+
+/**
+ *
+ * @author Holger Stenger
+ */
+public enum RenderOption {
+    /** Resolve relative links using source document location. */
+    RESOLVE_LINK_URLS,
+    /** Resolve relative image paths using source document location. */
+    RESOLVE_IMAGE_URLS,
+    /** Generate output which can be rendered by Swing. */
+    SWING_COMPATIBLE,
+    /** If the file is currently opened in the editor, use the editor content instead of the file content. */
+    PREFER_EDITOR
+}

--- a/src/flow/netbeans/markdown/api/Renderable.java
+++ b/src/flow/netbeans/markdown/api/Renderable.java
@@ -1,0 +1,13 @@
+
+package flow.netbeans.markdown.api;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ *
+ * @author Holger Stenger
+ */
+public interface Renderable {
+    String renderAsHtml(Set<RenderOption> renderOptions) throws IOException;
+}


### PR DESCRIPTION
This patch introduces an API for rendering the content of the file as HTML. The API consists of the interface `Renderable` which is available from the lookup of a Markdown data object.

The API encapsulates getting the file content, creating the PegDown parser and access to the global Markdown options. API users can specify several options to
- select whether the content of the editor (if available) is preferred over the content on disk
- convert relative image paths to absolute URLs
- convert relative links to absolute URLs
- use a simplified HTML template to create Swing compatible output

This patch also updates the preview pane, preview action and export action to make use of the new API.
