### PR TITLE
Set "requireProject" false

### DIFF
--- a/src/flow/netbeans/markdown/resources/layer.xml
+++ b/src/flow/netbeans/markdown/resources/layer.xml
@@ -124,6 +124,7 @@
                 <attr name="displayName" bundlevalue="flow.netbeans.markdown.resources.Bundle#Templates/Other/MarkdownTemplate.md"/>
                 <attr name="templateWizardURL" urlvalue="nbresloc:/flow/netbeans/markdown/resources/MarkdownTemplateDescription.html"/>
                 <attr name="template" boolvalue="true"/>
+                <attr name="requireProject" boolvalue="false"/>
             </file>
         </folder>
     </folder>


### PR DESCRIPTION
Refs #75 - Set `requireProject` attribute of template registration to `false` to allow the creation of Markdown files without needing a current project.
