### PR TITLE
Preserve scroll position in preview

### DIFF
--- a/src/flow/netbeans/markdown/preview/ext/FXHtmlView.java
+++ b/src/flow/netbeans/markdown/preview/ext/FXHtmlView.java
@@ -47,7 +47,6 @@ public class FXHtmlView extends AbstractHtmlView {
         Platform.runLater(new Runnable() {
             @Override
             public void run() {
-                //currentContent = content.replace("</head>", "<script type=\"text/javascript\">window.onload = function(){window.onbeforeunload = function() {return \"***navigation-hook***\";};};</script></head>");
                 currentContent = content;
 
                 final Integer x = (Integer) webView.getEngine().executeScript("document.body.scrollLeft");
@@ -82,12 +81,6 @@ public class FXHtmlView extends AbstractHtmlView {
         webView.setMinSize(widthDouble, heightDouble);
         webView.setPrefSize(widthDouble, heightDouble);
         webView.setContextMenuEnabled(false);
-//        webView.getEngine().setCreatePopupHandler(new Callback<PopupFeatures, WebEngine>() {
-//            @Override
-//            public WebEngine call(PopupFeatures p) {
-//                return null;
-//            }
-//        });
         webView.getEngine().setConfirmHandler(new Callback<String, Boolean>() {
             @Override
             public Boolean call(String p) {

--- a/src/flow/netbeans/markdown/preview/ext/FXHtmlView.java
+++ b/src/flow/netbeans/markdown/preview/ext/FXHtmlView.java
@@ -1,7 +1,6 @@
 package flow.netbeans.markdown.preview.ext;
 
 import flow.netbeans.markdown.preview.AbstractHtmlView;
-import java.text.MessageFormat;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -63,7 +62,7 @@ public class FXHtmlView extends AbstractHtmlView {
                         switch (newValue) {
                             case SUCCEEDED:
                                 loadWorker.stateProperty().removeListener(this);
-                                String script = MessageFormat.format("window.scrollTo({0},{1});", x, y);
+                                String script = String.format("window.scrollTo(%d,%d);", x, y);
                                 webView.getEngine().executeScript(script);
                                 break;
                             case FAILED:

--- a/src/flow/netbeans/markdown/preview/ext/FXHtmlView.java
+++ b/src/flow/netbeans/markdown/preview/ext/FXHtmlView.java
@@ -50,8 +50,8 @@ public class FXHtmlView extends AbstractHtmlView {
             public void run() {
                 currentContent = content;
 
-                final Number x = (Integer) webView.getEngine().executeScript("document.body.scrollLeft");
-                final Number y = (Integer) webView.getEngine().executeScript("document.body.scrollTop");
+                final Number x = (Number) webView.getEngine().executeScript("document.body.scrollLeft");
+                final Number y = (Number) webView.getEngine().executeScript("document.body.scrollTop");
 
                 webView.getEngine().loadContent(currentContent);
 


### PR DESCRIPTION
An attempt at preserving - or rather restoring - the scroll position in the JavaFX based preview. The preview may flicker or jerk to the top while the updated HTML loads. This effect may be unnoticeable on short documents which appear to update instantly. Embedded images make the effect very noticeable, especially if they are loaded from a remote server

See also #42.
